### PR TITLE
Closes #12. …

### DIFF
--- a/lib/jslacker/SQLConnector.js
+++ b/lib/jslacker/SQLConnector.js
@@ -1,7 +1,13 @@
 const dotenv = require('dotenv');
 const sql = require('mssql');
+const DOMParser = require('xmldom').DOMParser;
 
 dotenv.config();
+
+const ResponseType = {
+  RECORDSET: 0,
+  XML: 1,
+};
 
 const config = {
   user: process.env.DB_USER,
@@ -14,6 +20,7 @@ const config = {
     encrypt: false, // Use this if you're on Windows Azure
   },
 };
+
 const connectionPool = new sql.ConnectionPool(config);
 const transaction = connectionPool.transaction();
 
@@ -59,7 +66,16 @@ async function openConnection() {
   }
 }
 
-async function query(statement, parameters) {
+function prepareResponseType(response, responseType) {
+  if (responseType === ResponseType.XML) {
+    const results = response.recordset;
+    const innerXML = results[0][Object.keys(results[0])];
+    return new DOMParser().parseFromString(innerXML);
+  }
+  return response.recordset;
+}
+
+async function query(statement, parameters, responseType = null) {
   const request = connectionPool.request();
   if (parameters) {
     parameters.forEach((param) => {
@@ -68,7 +84,7 @@ async function query(statement, parameters) {
   }
   await openConnection();
   const response = await request.query(statement);
-  return response.recordset;
+  return prepareResponseType(response, responseType);
 }
 
 exports.query = query;
@@ -78,3 +94,5 @@ exports.connectionPool = connectionPool;
 exports.beginTransaction = beginTransaction;
 exports.rollbackTransaction = rollbackTransaction;
 exports.isInTransaction = isInTransaction;
+exports.prepareResponseType = prepareResponseType;
+exports.ResponseType = ResponseType;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7543,6 +7543,16 @@
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+    },
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "chai-as-promised": "^7.1.1",
     "csvtojson": "^1.1.7",
     "dotenv": "^4.0.0",
-    "mssql": "^4.0.4"
+    "mssql": "^4.0.4",
+    "xmldom": "^0.1.27",
+    "xpath": "0.0.27"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Added ResponseTypes ENUM so that the SQLConnector.query() function can return different objects based on the response type required. At present this includes XML and the standard recordset object